### PR TITLE
Lybrary files renamed as per convention

### DIFF
--- a/lib/Provider.dart
+++ b/lib/Provider.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:sprinkle/Overseer.dart';
+import 'supervisor.dart';
 
 class Provider extends InheritedWidget {
   final Supervisor data;

--- a/lib/Supervisor.dart
+++ b/lib/Supervisor.dart
@@ -1,29 +1,30 @@
-import 'Manager.dart';
+import 'manager.dart';
 
 typedef ManagerFormula = Manager Function();
 
 class Supervisor {
-  Map<dynamic, Manager> store = {};
-  Map<dynamic, ManagerFormula> formulas = {};
+  Map<dynamic, Manager> _store = {};
+  Map<dynamic, ManagerFormula> _formulas = {};
 
   Supervisor register<T extends Manager>(ManagerFormula formula) {
-    formulas[T] = formula;
+    _formulas[T] = formula;
     return this;
   }
 
   _fetch(name) {
-    var manager = formulas[name]();
+    var manager = _formulas[name]();
     manager.use = <T>() => summon<T>();
 
-    store[name] = manager;
+    _store[name] = manager;
 
     return manager;
   }
-  T summon<T>() => store.containsKey(T) ? store[T] : _fetch(T);
+
+  T summon<T>() => _store.containsKey(T) ? _store[T] : _fetch(T);
 
   release(name) {
-    Manager manager = store[name];
+    Manager manager = _store[name];
     manager.dispose();
-    store.remove(name);
+    _store.remove(name);
   }
 }

--- a/lib/manager.dart
+++ b/lib/manager.dart
@@ -1,0 +1,6 @@
+typedef UseFunction = T Function<T>();
+
+abstract class Manager {
+  UseFunction use;
+  void dispose();
+}

--- a/lib/observer.dart
+++ b/lib/observer.dart
@@ -1,0 +1,45 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+typedef _OnSuccessFunction<T> = Widget Function(BuildContext context, T data);
+typedef _OnErrorFunction = Widget Function(BuildContext context, Object error);
+typedef _OnWaitingFunction = Widget Function(BuildContext context);
+
+class Observer<T> extends StatelessWidget {
+ 
+  final Stream<T> stream;
+
+  final _OnSuccessFunction<T> onSuccess;
+  final _OnWaitingFunction onWaiting;
+  final _OnErrorFunction onError;
+
+  const Observer({Key key, @required this.stream, @required this.onSuccess, this.onWaiting, this.onError}) : super(key: key);
+
+  Function get _defaultOnWaiting =>
+    (context) => Center(child: CircularProgressIndicator());
+  Function get _defaultOnError => (context, error) => Text(error);
+
+  @override
+  Widget build(BuildContext context) {
+        return StreamBuilder(
+      stream: stream,
+      builder: (context, AsyncSnapshot<T> snapshot) {
+        if (snapshot.hasError) {
+          return (onError != null)
+              ? onError(context, snapshot.error)
+              : _defaultOnError(context, snapshot.error);
+        }
+
+        if (snapshot.hasData) {
+          T data = snapshot.data;
+          return onSuccess(context, data);
+        } else {
+          return (onWaiting != null)
+              ? onWaiting(context)
+              : _defaultOnWaiting(context);
+        }
+      },
+    );
+  }
+}

--- a/lib/provider.dart
+++ b/lib/provider.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'supervisor.dart';
+
+class Provider extends InheritedWidget {
+  final Supervisor data;
+
+  Provider({Key key, Widget child, this.data}) : super(key: key, child: child);
+
+  static Supervisor of(BuildContext context) {
+    return (context.dependOnInheritedWidgetOfExactType<Provider>()).data;
+  }
+
+  @override
+  bool updateShouldNotify(InheritedWidget oldWidget) {
+    return false;
+  }
+}

--- a/lib/service.dart
+++ b/lib/service.dart
@@ -1,0 +1,3 @@
+abstract class Service<T> {
+  Future<List<T>> browse({String filter});
+}

--- a/lib/sprinkle.dart
+++ b/lib/sprinkle.dart
@@ -1,3 +1,3 @@
 library sprinkle;
 
-export 'SprinkleExtension.dart';
+export 'sprinkle_extension.dart';

--- a/lib/sprinkle_extension.dart
+++ b/lib/sprinkle_extension.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/widgets.dart';
-
-import 'Provider.dart';
+import 'provider.dart';
 
 extension SprinkleExtension<T> on BuildContext {
   T use<T>() => Provider.of(this).summon<T>();

--- a/lib/supervisor.dart
+++ b/lib/supervisor.dart
@@ -1,0 +1,30 @@
+import 'manager.dart';
+
+typedef ManagerFormula = Manager Function();
+
+class Supervisor {
+  Map<dynamic, Manager> _store = {};
+  Map<dynamic, ManagerFormula> _formulas = {};
+
+  Supervisor register<T extends Manager>(ManagerFormula formula) {
+    _formulas[T] = formula;
+    return this;
+  }
+
+  _fetch(name) {
+    var manager = _formulas[name]();
+    manager.use = <T>() => summon<T>();
+
+    _store[name] = manager;
+
+    return manager;
+  }
+
+  T summon<T>() => _store.containsKey(T) ? _store[T] : _fetch(T);
+
+  release(name) {
+    Manager manager = _store[name];
+    manager.dispose();
+    _store.remove(name);
+  }
+}

--- a/lib/web_resource_manager.dart
+++ b/lib/web_resource_manager.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 
 import 'package:rxdart/rxdart.dart';
-import 'package:sprinkle/Manager.dart';
-import 'package:sprinkle/Service.dart';
+import 'manager.dart';
+import 'service.dart';
 
 class WebResourceManager<T> implements Manager {
   final PublishSubject<String> _filterSubject = PublishSubject<String>();
@@ -34,6 +34,5 @@ class WebResourceManager<T> implements Manager {
   }
 
   @override
-  T Function<T>() dispatch;
-
+  T Function<T>() use;
 }


### PR DESCRIPTION
All files and imports has been renamed as per Effective Dart, main focus on: https://dart.dev/guides/language/effective-dart/style#do-name-libraries-and-source-files-using-lowercase_with_underscores

Also, added use() function in manager.dart